### PR TITLE
API geolocation

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": []
+}

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'puma', '~> 5.0'
 gem 'rack-cors', require: 'rack/cors'
 gem 'rest-client'
 gem 'rails', '~> 6.1.3', '>= 6.1.3.1'
+gem 'geocoder'
 
 group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,7 @@ GEM
       factory_bot (~> 6.1.0)
       railties (>= 5.0.0)
     ffi (1.15.0)
+    geocoder (1.6.7)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     hashdiff (1.0.1)
@@ -231,6 +232,7 @@ DEPENDENCIES
   byebug
   coveralls
   factory_bot_rails
+  geocoder
   listen (~> 3.3)
   pg (~> 1.1)
   pry-rails

--- a/app/controllers/api/movies_controller.rb
+++ b/app/controllers/api/movies_controller.rb
@@ -3,11 +3,17 @@ class Api::MoviesController < ApplicationController
     netflix = Rails.application.credentials.unogsng_key
 
     begin
+      
       response = RestClient.get('https://unogsng.p.rapidapi.com/search?type=movie&orderby=rating',
                                 headers = { 'x-rapidapi-key': netflix })
-      results = JSON.parse(response)['results'].select { |film| film['avgrating'] > 4 }
-      netflix_sorted = results.sort_by { |film| film['avgrating'] }.reverse
-      render json: { body: netflix_sorted[0..9] }, status: 200
+      if results = Geocoder.search([params[:lat],params[:long]]) 
+        binding.pry 
+                             
+      else  
+          results = JSON.parse(response)['results'].select { |film| film['avgrating'] > 4 }
+          netflix_sorted = results.sort_by { |film| film['avgrating'] }.reverse
+          render json: { body: netflix_sorted[0..9] }, status: 200
+      end
     rescue StandardError => e
       render json: { error: e.response.description }, status: e.response.code
     end

--- a/app/controllers/api/movies_controller.rb
+++ b/app/controllers/api/movies_controller.rb
@@ -12,6 +12,7 @@ class Api::MoviesController < ApplicationController
         movie_array = JSON.parse(response.body)['results']
 
         movie_results = movie_array.select { |movie| !movie['clist'].include?(country) }
+        render json: { body: movie_results[0..9]}, status: 200
 
       elsif response = RestClient.get('https://unogsng.p.rapidapi.com/search?type=movie&orderby=rating',
                                       headers = { 'x-rapidapi-key': netflix })

--- a/app/controllers/api/movies_controller.rb
+++ b/app/controllers/api/movies_controller.rb
@@ -6,12 +6,16 @@ class Api::MoviesController < ApplicationController
       if params.has_key?(:lat) && params.has_key?(:long)
         results = Geocoder.search([params[:lat], params[:long]])
         country = results.first.country
-        binding.pry
 
+        response = RestClient.get('https://unogsng.p.rapidapi.com/search?type=movie&orderby=rating',
+                                  headers = { 'x-rapidapi-key': netflix })
+        results = JSON.parse(response)['results'].select { |film| film['clist'] != country }
+        binding.pry
       elsif response = RestClient.get('https://unogsng.p.rapidapi.com/search?type=movie&orderby=rating',
                                       headers = { 'x-rapidapi-key': netflix })
 
         results = JSON.parse(response)['results'].select { |film| film['avgrating'] > 4 }
+
         netflix_sorted = results.sort_by { |film| film['avgrating'] }.reverse
         render json: { body: netflix_sorted[0..9] }, status: 200
 

--- a/app/controllers/api/movies_controller.rb
+++ b/app/controllers/api/movies_controller.rb
@@ -3,16 +3,18 @@ class Api::MoviesController < ApplicationController
     netflix = Rails.application.credentials.unogsng_key
 
     begin
-      
-      response = RestClient.get('https://unogsng.p.rapidapi.com/search?type=movie&orderby=rating',
-                                headers = { 'x-rapidapi-key': netflix })
-      if results = Geocoder.search([params[:lat],params[:long]]) 
-        binding.pry 
-                             
-      else  
-          results = JSON.parse(response)['results'].select { |film| film['avgrating'] > 4 }
-          netflix_sorted = results.sort_by { |film| film['avgrating'] }.reverse
-          render json: { body: netflix_sorted[0..9] }, status: 200
+      if params.has_key?(:lat) && params.has_key?(:long)
+        results = Geocoder.search([params[:lat], params[:long]])
+        country = results.first.country
+        binding.pry
+
+      elsif response = RestClient.get('https://unogsng.p.rapidapi.com/search?type=movie&orderby=rating',
+                                      headers = { 'x-rapidapi-key': netflix })
+
+        results = JSON.parse(response)['results'].select { |film| film['avgrating'] > 4 }
+        netflix_sorted = results.sort_by { |film| film['avgrating'] }.reverse
+        render json: { body: netflix_sorted[0..9] }, status: 200
+
       end
     rescue StandardError => e
       render json: { error: e.response.description }, status: e.response.code

--- a/app/controllers/api/movies_controller.rb
+++ b/app/controllers/api/movies_controller.rb
@@ -6,19 +6,19 @@ class Api::MoviesController < ApplicationController
       if params.has_key?(:lat) && params.has_key?(:long)
         results = Geocoder.search([params[:lat], params[:long]])
         country = results.first.country
-
-        response = RestClient.get('https://unogsng.p.rapidapi.com/search?type=movie&orderby=rating',
+        binding.pry
+        response = RestClient.get("https://unogsng.p.rapidapi.com/search?type=movie&orderby=rating",
                                   headers = { 'x-rapidapi-key': netflix })
         results = JSON.parse(response)['results'].select { |film| film['clist'] != country }
+        # movie_array = JSON.parse(response.body)["body"]
+        # movie_results = movie_array.select { |movie| movie["clist"].include?(country) }
         binding.pry
-      elsif response = RestClient.get('https://unogsng.p.rapidapi.com/search?type=movie&orderby=rating',
+      elsif response = RestClient.get("https://unogsng.p.rapidapi.com/search?type=movie&orderby=rating",
                                       headers = { 'x-rapidapi-key': netflix })
+        results = JSON.parse(response)["results"].select { |film| film["avgrating"] > 4 }
 
-        results = JSON.parse(response)['results'].select { |film| film['avgrating'] > 4 }
-
-        netflix_sorted = results.sort_by { |film| film['avgrating'] }.reverse
+        netflix_sorted = results.sort_by { |film| film["avgrating"] }.reverse
         render json: { body: netflix_sorted[0..9] }, status: 200
-
       end
     rescue StandardError => e
       render json: { error: e.response.description }, status: e.response.code

--- a/app/controllers/api/movies_controller.rb
+++ b/app/controllers/api/movies_controller.rb
@@ -3,21 +3,21 @@ class Api::MoviesController < ApplicationController
     netflix = Rails.application.credentials.unogsng_key
 
     begin
-      if params.has_key?(:lat) && params.has_key?(:long)
-        results = Geocoder.search([params[:lat], params[:long]])
-        country = results.first.country
-        binding.pry
-        response = RestClient.get("https://unogsng.p.rapidapi.com/search?type=movie&orderby=rating",
-                                  headers = { 'x-rapidapi-key': netflix })
-        results = JSON.parse(response)['results'].select { |film| film['clist'] != country }
-        # movie_array = JSON.parse(response.body)["body"]
-        # movie_results = movie_array.select { |movie| movie["clist"].include?(country) }
-        binding.pry
-      elsif response = RestClient.get("https://unogsng.p.rapidapi.com/search?type=movie&orderby=rating",
-                                      headers = { 'x-rapidapi-key': netflix })
-        results = JSON.parse(response)["results"].select { |film| film["avgrating"] > 4 }
+      if params.has_key?(:lat) && params.has_key?(:lon)
+        country_results = Geocoder.search([params[:lat], params[:lon]])
+        country = country_results.first.country
 
-        netflix_sorted = results.sort_by { |film| film["avgrating"] }.reverse
+        response = RestClient.get('https://unogsng.p.rapidapi.com/search?type=movie&orderby=rating',
+                                  headers = { 'x-rapidapi-key': netflix })
+        movie_array = JSON.parse(response.body)['results']
+
+        movie_results = movie_array.select { |movie| !movie['clist'].include?(country) }
+
+      elsif response = RestClient.get('https://unogsng.p.rapidapi.com/search?type=movie&orderby=rating',
+                                      headers = { 'x-rapidapi-key': netflix })
+        results = JSON.parse(response)['results'].select { |film| film['avgrating'] > 4 }
+
+        netflix_sorted = results.sort_by { |film| film['avgrating'] }.reverse
         render json: { body: netflix_sorted[0..9] }, status: 200
       end
     rescue StandardError => e

--- a/spec/fixtures/files/visitor_location.json
+++ b/spec/fixtures/files/visitor_location.json
@@ -1,25 +1,26 @@
 {
-    "place_id": 42215472,
+    "place_id": 167278793,
     "licence": "Data © OpenStreetMap contributors, ODbL 1.0. https://osm.org/copyright",
-    "osm_type": "node",
-    "osm_id": 3185256527,
-    "lat": "55.78414",
-    "lon": "12.451736",
-    "display_name": "193A, Hummeltoftevej, Frederiksdal, Lyngby-Taarbæk Municipality, Capital Region of Denmark, 2830, Denmark",
+    "osm_type": "way",
+    "osm_id": 316896325,
+    "lat": "59.32021159999999",
+    "lon": "18.378402470899054",
+    "display_name": "32, Hjalmar Olssons väg, Charlottendal, Gustavsberg, Värmdö kommun, Stockholm County, 134 52, Sweden",
     "address": {
-        "house_number": "193A",
-        "road": "Hummeltoftevej",
-        "hamlet": "Frederiksdal",
-        "municipality": "Lyngby-Taarbæk Municipality",
-        "state": "Capital Region of Denmark",
-        "postcode": "2830",
-        "country": "Denmark",
-        "country_code": "dk"
+      "house_number": "32",
+      "road": "Hjalmar Olssons väg",
+      "suburb": "Charlottendal",
+      "town": "Gustavsberg",
+      "municipality": "Värmdö kommun",
+      "county": "Stockholm County",
+      "postcode": "134 52",
+      "country": "Sweden",
+      "country_code": "se"
     },
     "boundingbox": [
-        "55.78409",
-        "55.78419",
-        "12.451686",
-        "12.451786"
+      "59.320115",
+      "59.3202536",
+      "18.3782841",
+      "18.3785009"
     ]
-}
+  }

--- a/spec/fixtures/files/visitor_location.json
+++ b/spec/fixtures/files/visitor_location.json
@@ -1,144 +1,25 @@
 {
-  "documentation": "https://opencagedata.com/api",
-  "licenses": [
-      {
-          "name": "see attribution guide",
-          "url": "https://opencagedata.com/credits"
-      }
-  ],
-  "rate": {
-      "limit": 2500,
-      "remaining": 2474,
-      "reset": 1620345600
-  },
-  "results": [
-      {
-          "annotations": {
-              "DMS": {
-                  "lat": "56° 29' 44.79036'' N",
-                  "lng": "60° 14' 12.19056'' E"
-              },
-              "MGRS": "41VLC2989864681",
-              "Maidenhead": "MO06cl88jx",
-              "Mercator": {
-                  "x": 6705520.955,
-                  "y": 7622091.585
-              },
-              "OSM": {
-                  "edit_url": "https://www.openstreetmap.org/edit?way=96778420#map=16/56.49578/60.23672",
-                  "note_url": "https://www.openstreetmap.org/note/new#map=16/56.49578/60.23672&layers=N",
-                  "url": "https://www.openstreetmap.org/?mlat=56.49578&mlon=60.23672#map=16/56.49578/60.23672"
-              },
-              "UN_M49": {
-                  "regions": {
-                      "EASTERN_EUROPE": "151",
-                      "EUROPE": "150",
-                      "RU": "643",
-                      "WORLD": "001"
-                  },
-                  "statistical_groupings": [
-                      "MEDC"
-                  ]
-              },
-              "callingcode": 7,
-              "currency": {
-                  "alternate_symbols": [
-                      "руб.",
-                      "р."
-                  ],
-                  "decimal_mark": ",",
-                  "format": "%n %u",
-                  "html_entity": "&#x20BD;",
-                  "iso_code": "RUB",
-                  "iso_numeric": "643",
-                  "name": "Russian Ruble",
-                  "smallest_denomination": 1,
-                  "subunit": "Kopeck",
-                  "subunit_to_unit": 100,
-                  "symbol": "₽",
-                  "symbol_first": 0,
-                  "thousands_separator": "."
-              },
-              "flag": "🇷🇺",
-              "geohash": "v64c6sxp9rc9e6e2dgpt",
-              "qibla": 211.69,
-              "roadinfo": {
-                  "drive_on": "right",
-                  "road": "улица Ленина",
-                  "speed_in": "km/h"
-              },
-              "sun": {
-                  "rise": {
-                      "apparent": 1620259440,
-                      "astronomical": 0,
-                      "civil": 1620343020,
-                      "nautical": 1620338940
-                  },
-                  "set": {
-                      "apparent": 1620316140,
-                      "astronomical": 0,
-                      "civil": 1620319020,
-                      "nautical": 1620323100
-                  }
-              },
-              "timezone": {
-                  "name": "Asia/Yekaterinburg",
-                  "now_in_dst": 0,
-                  "offset_sec": 18000,
-                  "offset_string": "+0500",
-                  "short_name": "+05"
-              },
-              "what3words": {
-                  "words": "aspire.illustrating.quid"
-              }
-          },
-          "bounds": {
-              "northeast": {
-                  "lat": 56.4963718,
-                  "lng": 60.2375656
-              },
-              "southwest": {
-                  "lat": 56.4953753,
-                  "lng": 60.2357572
-              }
-          },
-          "components": {
-              "ISO_3166-1_alpha-2": "RU",
-              "ISO_3166-1_alpha-3": "RUS",
-              "_category": "transportation",
-              "_type": "parking",
-              "continent": "Europe",
-              "country": "Russia",
-              "country_code": "ru",
-              "county": "Полевской городской округ",
-              "parking": "площадь В.И.Ленина",
-              "postcode": "623380",
-              "region": "Ural Federal District",
-              "road": "улица Ленина",
-              "state": "Sverdlovsk Oblast",
-              "suburb": "микрорайон Ялунина",
-              "town": "Polevskoy"
-          },
-          "confidence": 9,
-          "formatted": "площадь В.И.Ленина, улица Ленина, микрорайон Ялунина, Polevskoy, Sverdlovsk Oblast, Russia, 623380",
-          "geometry": {
-              "lat": 56.4957751,
-              "lng": 60.2367196
-          }
-      }
-  ],
-  "status": {
-      "code": 200,
-      "message": "OK"
-  },
-  "stay_informed": {
-      "blog": "https://blog.opencagedata.com",
-      "twitter": "https://twitter.com/OpenCage"
-  },
-  "thanks": "For using an OpenCage API",
-  "timestamp": {
-      "created_http": "Thu, 06 May 2021 17:40:11 GMT",
-      "created_unix": 1620322811
-  },
-  "total_results": 1
+    "place_id": 42215472,
+    "licence": "Data © OpenStreetMap contributors, ODbL 1.0. https://osm.org/copyright",
+    "osm_type": "node",
+    "osm_id": 3185256527,
+    "lat": "55.78414",
+    "lon": "12.451736",
+    "display_name": "193A, Hummeltoftevej, Frederiksdal, Lyngby-Taarbæk Municipality, Capital Region of Denmark, 2830, Denmark",
+    "address": {
+        "house_number": "193A",
+        "road": "Hummeltoftevej",
+        "hamlet": "Frederiksdal",
+        "municipality": "Lyngby-Taarbæk Municipality",
+        "state": "Capital Region of Denmark",
+        "postcode": "2830",
+        "country": "Denmark",
+        "country_code": "dk"
+    },
+    "boundingbox": [
+        "55.78409",
+        "55.78419",
+        "12.451686",
+        "12.451786"
+    ]
 }

--- a/spec/fixtures/files/visitor_location.json
+++ b/spec/fixtures/files/visitor_location.json
@@ -1,0 +1,144 @@
+{
+  "documentation": "https://opencagedata.com/api",
+  "licenses": [
+      {
+          "name": "see attribution guide",
+          "url": "https://opencagedata.com/credits"
+      }
+  ],
+  "rate": {
+      "limit": 2500,
+      "remaining": 2474,
+      "reset": 1620345600
+  },
+  "results": [
+      {
+          "annotations": {
+              "DMS": {
+                  "lat": "56° 29' 44.79036'' N",
+                  "lng": "60° 14' 12.19056'' E"
+              },
+              "MGRS": "41VLC2989864681",
+              "Maidenhead": "MO06cl88jx",
+              "Mercator": {
+                  "x": 6705520.955,
+                  "y": 7622091.585
+              },
+              "OSM": {
+                  "edit_url": "https://www.openstreetmap.org/edit?way=96778420#map=16/56.49578/60.23672",
+                  "note_url": "https://www.openstreetmap.org/note/new#map=16/56.49578/60.23672&layers=N",
+                  "url": "https://www.openstreetmap.org/?mlat=56.49578&mlon=60.23672#map=16/56.49578/60.23672"
+              },
+              "UN_M49": {
+                  "regions": {
+                      "EASTERN_EUROPE": "151",
+                      "EUROPE": "150",
+                      "RU": "643",
+                      "WORLD": "001"
+                  },
+                  "statistical_groupings": [
+                      "MEDC"
+                  ]
+              },
+              "callingcode": 7,
+              "currency": {
+                  "alternate_symbols": [
+                      "руб.",
+                      "р."
+                  ],
+                  "decimal_mark": ",",
+                  "format": "%n %u",
+                  "html_entity": "&#x20BD;",
+                  "iso_code": "RUB",
+                  "iso_numeric": "643",
+                  "name": "Russian Ruble",
+                  "smallest_denomination": 1,
+                  "subunit": "Kopeck",
+                  "subunit_to_unit": 100,
+                  "symbol": "₽",
+                  "symbol_first": 0,
+                  "thousands_separator": "."
+              },
+              "flag": "🇷🇺",
+              "geohash": "v64c6sxp9rc9e6e2dgpt",
+              "qibla": 211.69,
+              "roadinfo": {
+                  "drive_on": "right",
+                  "road": "улица Ленина",
+                  "speed_in": "km/h"
+              },
+              "sun": {
+                  "rise": {
+                      "apparent": 1620259440,
+                      "astronomical": 0,
+                      "civil": 1620343020,
+                      "nautical": 1620338940
+                  },
+                  "set": {
+                      "apparent": 1620316140,
+                      "astronomical": 0,
+                      "civil": 1620319020,
+                      "nautical": 1620323100
+                  }
+              },
+              "timezone": {
+                  "name": "Asia/Yekaterinburg",
+                  "now_in_dst": 0,
+                  "offset_sec": 18000,
+                  "offset_string": "+0500",
+                  "short_name": "+05"
+              },
+              "what3words": {
+                  "words": "aspire.illustrating.quid"
+              }
+          },
+          "bounds": {
+              "northeast": {
+                  "lat": 56.4963718,
+                  "lng": 60.2375656
+              },
+              "southwest": {
+                  "lat": 56.4953753,
+                  "lng": 60.2357572
+              }
+          },
+          "components": {
+              "ISO_3166-1_alpha-2": "RU",
+              "ISO_3166-1_alpha-3": "RUS",
+              "_category": "transportation",
+              "_type": "parking",
+              "continent": "Europe",
+              "country": "Russia",
+              "country_code": "ru",
+              "county": "Полевской городской округ",
+              "parking": "площадь В.И.Ленина",
+              "postcode": "623380",
+              "region": "Ural Federal District",
+              "road": "улица Ленина",
+              "state": "Sverdlovsk Oblast",
+              "suburb": "микрорайон Ялунина",
+              "town": "Polevskoy"
+          },
+          "confidence": 9,
+          "formatted": "площадь В.И.Ленина, улица Ленина, микрорайон Ялунина, Polevskoy, Sverdlovsk Oblast, Russia, 623380",
+          "geometry": {
+              "lat": 56.4957751,
+              "lng": 60.2367196
+          }
+      }
+  ],
+  "status": {
+      "code": 200,
+      "message": "OK"
+  },
+  "stay_informed": {
+      "blog": "https://blog.opencagedata.com",
+      "twitter": "https://twitter.com/OpenCage"
+  },
+  "thanks": "For using an OpenCage API",
+  "timestamp": {
+      "created_http": "Thu, 06 May 2021 17:40:11 GMT",
+      "created_unix": 1620322811
+  },
+  "total_results": 1
+}

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,7 +7,7 @@ require File.expand_path('../config/environment', __dir__)
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
 require 'webmock/rspec'
-WebMock.enable_net_connect!
+WebMock.disable_net_connect!
 Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
 
 ActiveRecord::Migration.maintain_test_schema!

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,7 @@ require File.expand_path('../config/environment', __dir__)
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
 require 'webmock/rspec'
+WebMock.enable_net_connect!
 Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
 
 ActiveRecord::Migration.maintain_test_schema!

--- a/spec/requests/api/location_api_responds_spec.rb
+++ b/spec/requests/api/location_api_responds_spec.rb
@@ -18,8 +18,6 @@ RSpec.describe 'GET /api/movies/' do
     expect(response).to have_http_status 200
   end
   it 'is expected to return list of 10 movies' do
-    binding.pry
-
     expect(response_json['body'].count).to eq 10
   end
   it 'is expected to show a list of 10 movies from outside the visitors country' do

--- a/spec/requests/api/location_api_responds_spec.rb
+++ b/spec/requests/api/location_api_responds_spec.rb
@@ -1,0 +1,20 @@
+RSpec.describe 'GET /api/movies/' do
+  # let (:geocoder) {create(:geocoder)}
+    before do
+      get '/api/movies?lat=55.7842&long=12.4518'
+      # Geocoder.configure(lookup: :test)
+      # Geocoder::Lookup::Test.set_default_stub(
+      #   [
+      #     {
+      #       'latitude'     => 55.7842,
+      #       'longitude'    => 12.4518,
+      #       'country' => 'Denmark'
+      #     },
+      #   ]
+      # )
+    end
+    it 'is expected to return status 200' do
+      binding.pry
+      expect(response_json).to have_http_status 200 
+    end
+end

--- a/spec/requests/api/location_api_responds_spec.rb
+++ b/spec/requests/api/location_api_responds_spec.rb
@@ -11,9 +11,16 @@ RSpec.describe 'GET /api/movies/' do
     stub_request(:get, 'https://unogsng.p.rapidapi.com/search?type=movie&orderby=rating')
       .to_return(status: 200, body: top_100_response)
 
-    get '/api/movies'
+    get '/api/movies/?lat=55.7842&lon=12.4518'
   end
   it 'is expected to return status 200' do
     expect(response).to have_http_status 200
+  end
+  it 'is expected to return list of 10 movies' do
+    expect(response_json['body'].count).to eq 10
+  end
+  it 'is expected to show a list of 10 movies from outside the visitors country' do
+    binding.pry
+   expect(response_json['body']).not_to include('Denmark')
   end
 end

--- a/spec/requests/api/location_api_responds_spec.rb
+++ b/spec/requests/api/location_api_responds_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe 'GET /api/movies/' do
   let(:top_100_response) do
     file_fixture('top_movie_search_api_response.json').read
   end
+
   before do
     stub_request(:get, 'https://nominatim.openstreetmap.org/reverse?accept-language=en&addressdetails=1&format=json&lat=55.7842&lon=12.4518')
       .to_return(status: 200, body: vistor_location, headers: {})
@@ -20,7 +21,6 @@ RSpec.describe 'GET /api/movies/' do
     expect(response_json['body'].count).to eq 10
   end
   it 'is expected to show a list of 10 movies from outside the visitors country' do
-    binding.pry
-   expect(response_json['body']).not_to include('Denmark')
+    expect(response_json['body']).not_to include('Denmark')
   end
 end

--- a/spec/requests/api/location_api_responds_spec.rb
+++ b/spec/requests/api/location_api_responds_spec.rb
@@ -1,26 +1,28 @@
 RSpec.describe 'GET /api/movies/' do
   let(:vistor_location) do
-    file_fixture('visitor_location.json')
+    file_fixture('visitor_location.json').read
   end
   let(:top_100_response) do
     file_fixture('top_movie_search_api_response.json').read
   end
 
   before do
-    stub_request(:get, 'https://nominatim.openstreetmap.org/reverse?accept-language=en&addressdetails=1&format=json&lat=55.7842&lon=12.4518')
+    stub_request(:get, 'https://nominatim.openstreetmap.org/reverse?accept-language=en&addressdetails=1&format=json&lat=59.32021&lon=18.37827')
       .to_return(status: 200, body: vistor_location, headers: {})
     stub_request(:get, 'https://unogsng.p.rapidapi.com/search?type=movie&orderby=rating')
       .to_return(status: 200, body: top_100_response)
 
-    get '/api/movies/?lat=55.7842&lon=12.4518'
+    get '/api/movies/?lat=59.32021&lon=18.37827'
   end
   it 'is expected to return status 200' do
     expect(response).to have_http_status 200
   end
   it 'is expected to return list of 10 movies' do
+    binding.pry
+
     expect(response_json['body'].count).to eq 10
   end
   it 'is expected to show a list of 10 movies from outside the visitors country' do
-    expect(response_json['body']).not_to include('Denmark')
+    expect(response_json['body']).not_to include('Sweden')
   end
 end

--- a/spec/requests/api/location_api_responds_spec.rb
+++ b/spec/requests/api/location_api_responds_spec.rb
@@ -1,20 +1,19 @@
 RSpec.describe 'GET /api/movies/' do
-  # let (:geocoder) {create(:geocoder)}
-    before do
-      get '/api/movies?lat=55.7842&long=12.4518'
-      # Geocoder.configure(lookup: :test)
-      # Geocoder::Lookup::Test.set_default_stub(
-      #   [
-      #     {
-      #       'latitude'     => 55.7842,
-      #       'longitude'    => 12.4518,
-      #       'country' => 'Denmark'
-      #     },
-      #   ]
-      # )
-    end
-    it 'is expected to return status 200' do
-      binding.pry
-      expect(response_json).to have_http_status 200 
-    end
+  let(:vistor_location) do
+    file_fixture('visitor_location.json')
+  end
+  let(:top_100_response) do
+    file_fixture('top_movie_search_api_response.json').read
+  end
+  before do
+    stub_request(:get, 'https://nominatim.openstreetmap.org/reverse?accept-language=en&addressdetails=1&format=json&lat=55.7842&lon=12.4518')
+      .to_return(status: 200, body: vistor_location, headers: {})
+    stub_request(:get, 'https://unogsng.p.rapidapi.com/search?type=movie&orderby=rating')
+      .to_return(status: 200, body: top_100_response)
+
+    get '/api/movies'
+  end
+  it 'is expected to return status 200' do
+    expect(response).to have_http_status 200
+  end
 end

--- a/spec/requests/api/netflix_api_responds_with_top_10_movies_globally_spec.rb
+++ b/spec/requests/api/netflix_api_responds_with_top_10_movies_globally_spec.rb
@@ -39,6 +39,18 @@ RSpec.describe 'GET /api/movies', type: :request do
         .to_return(status: 200, body: top_100_response)
       get '/api/movies'
     end
+
+    it 'is expected to respond 200' do
+      expect(response).to have_http_status 200
+    end
+
+    it 'is expected to determine visitors country as russia' do
+      expect(response_json['body'])
+    end
+
+    it 'is expected to respond with top 10 movies thats not available in russia' do
+      expect()
+    end
   end
 
   describe 'Unsuccesfull' do

--- a/spec/requests/api/netflix_api_responds_with_top_10_movies_globally_spec.rb
+++ b/spec/requests/api/netflix_api_responds_with_top_10_movies_globally_spec.rb
@@ -31,29 +31,7 @@ RSpec.describe 'GET /api/movies', type: :request do
     end
   end
 
-  describe 'successfully recives a list of 10 movies unavalible in visitors country' do
-    before do
-      stub_request(:get, 'https://api.opencagedata.com/geocode/v1/json?q=56.4958+60.2365&key=c729c1ed1687492d808d5673e2b72991')
-        .to_return(status: 200, body: open_cage_response)
-      stub_request(:get, 'https://unogsng.p.rapidapi.com/search?type=movie&orderby=rating')
-        .to_return(status: 200, body: top_100_response)
-      get '/api/movies'
-    end
-
-    it 'is expected to respond 200' do
-      expect(response).to have_http_status 200
-    end
-
-    it 'is expected to determine visitors country as russia' do
-      expect(response_json['body'])
-    end
-
-    it 'is expected to respond with top 10 movies thats not available in russia' do
-      expect()
-    end
-  end
-
-  describe 'Unsuccesfull' do
+  describe 'Unsuccesfully' do
     before do
       stub_request(:get, 'https://unogsng.p.rapidapi.com/search?type=movie&orderby=rating')
         .to_return(status: 500, body: nil)

--- a/spec/requests/api/netflix_api_responds_with_top_10_movies_globally_spec.rb
+++ b/spec/requests/api/netflix_api_responds_with_top_10_movies_globally_spec.rb
@@ -7,7 +7,11 @@ RSpec.describe 'GET /api/movies', type: :request do
     file_fixture('top_10_avgrating_filter.json').read
   end
 
-  describe 'successfully receives top 100 movies globally' do
+  let(:open_cage_response) do
+    file_fixture('visitor_location.json')
+  end
+
+  describe 'successfully receives top 10 movies globally' do
     before do
       stub_request(:get, 'https://unogsng.p.rapidapi.com/search?type=movie&orderby=rating')
         .to_return(status: 200, body: top_100_response)
@@ -27,6 +31,16 @@ RSpec.describe 'GET /api/movies', type: :request do
     end
   end
 
+  describe 'successfully recives a list of 10 movies unavalible in visitors country' do
+    before do
+      stub_request(:get, 'https://api.opencagedata.com/geocode/v1/json?q=56.4958+60.2365&key=c729c1ed1687492d808d5673e2b72991')
+        .to_return(status: 200, body: open_cage_response)
+      stub_request(:get, 'https://unogsng.p.rapidapi.com/search?type=movie&orderby=rating')
+        .to_return(status: 200, body: top_100_response)
+      get '/api/movies'
+    end
+  end
+
   describe 'Unsuccesfull' do
     before do
       stub_request(:get, 'https://unogsng.p.rapidapi.com/search?type=movie&orderby=rating')
@@ -37,7 +51,7 @@ RSpec.describe 'GET /api/movies', type: :request do
     it 'is expected to respond 500' do
       expect(response).to have_http_status 500
     end
-    
+
     it 'is expected to have a message' do
       expect(response_json['error']).to eq "500 Internal Server Error |  0 bytes\n"
     end


### PR DESCRIPTION
Pt : https://www.pivotaltracker.com/story/show/178007118

### User story
```
As an API
To be able to show movies not from the visitors current location
We need to be able to locate user geolocation
```
### Changes proposed in this pull request: 
* Get visitor's latitude and longitude from client
*  Give list of 10 movies that are not available in visitor's country 

###  What I have learned working on this feature: 
* How to use Geocoder gem
*  include method 
*  how to use has_key?
*  how to use begin and rescue 